### PR TITLE
chore(dependencies): bump govuk-frontend from v4.6.0 to v4.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@dvsa/cookie-manager": "^1.0.*",
     "chosen-npm": "^1.4.2",
     "customizr": "^1.4.0",
-    "govuk-frontend": "^4.8.0",
+    "govuk-frontend": "4.8.0",
     "grunt": "^1.0.3",
     "grunt-cli": "^1.3.0",
     "grunt-contrib-clean": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@dvsa/cookie-manager": "^1.0.*",
     "chosen-npm": "^1.4.2",
     "customizr": "^1.4.0",
-    "govuk-frontend": "4.6.0",
+    "govuk-frontend": "^4.8.0",
     "grunt": "^1.0.3",
     "grunt-cli": "^1.3.0",
     "grunt-contrib-clean": "^1.1.0",


### PR DESCRIPTION
## Description
This PR updates the `govuk-frontend` dependency in our `olcs-static` repository from v4.6.0 to v4.8.0. This version bump introduces the ability to update the crown logo, aligning our application's branding with the latest GOV.UK design standards.

### Instructions
Instruction how to change: [here](https://github.com/alphagov/govuk-frontend/releases/tag/v4.8.0)

### Changes
- Updated `govuk-frontend` version in `package.json` from `4.6.0` to `4.8.0`.
- Adjusted `olcs-selfserve` assets and configurations to accommodate the new crown logo feature introduced in v4.8.0.

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
