### PR TITLE
feat: upgrade `govuk-frontend` to v5

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,8 +47,6 @@ var sass = require('sass');
                 'assets/_js/' + theme + '/*.js',
                 'assets/_js/init/common.js',
                 'assets/_js/init/' + theme + '.js',
-                'node_modules/govuk-frontend/govuk/all.js',
-
             ];
             if (theme === 'internal') {
                 files.push(
@@ -233,6 +231,14 @@ var sass = require('sass');
                         src: ['**/*.{woff2,woff,eot}'],
                         dest: 'public/assets/fonts/'
                     }]
+                },
+                govukJs: {
+                    files: [{
+                        expand: true,
+                        cwd: 'node_modules/govuk-frontend/dist/govuk/',
+                        src: ['govuk-frontend.min.js'],
+                        dest: 'public/js/'
+                    }]
                 }
             },
 
@@ -351,7 +357,14 @@ var sass = require('sass');
                     },
                     watchTask: true,
                     server: {
-                        baseDir: './public'
+                        baseDir: './public',
+                        middleware: function (req, res, next) {
+                            res.setHeader('Access-Control-Allow-Origin', '*');
+                            res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
+                            res.setHeader('Access-Control-Allow-Headers', 'X-Requested-With,content-type');
+                            res.setHeader('Access-Control-Allow-Credentials', true);
+                            next();
+                        }
                     }
                 }
             },
@@ -507,7 +520,8 @@ var sass = require('sass');
                 'sass:' + environment,
                 'postcss',
                 'uglify:' + environment,
-                'copyfonts'
+                'copyfonts',
+                'copy:govukJs'
             ];
         };
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -280,15 +280,15 @@ var sass = require('sass');
                     options: {
                         mode: {
                             css: { // Activate the «css» mode
-                                "dest": "../../../public/styles",
-                                "sprite": "../images/svg/icon-sprite.svg",
-                                "bust": true,
-                                "prefix": ".",
-                                "dimensions": true,
-                                "layout": "vertical",
-                                "render": {
-                                  "scss": {
-                                      "dest": path.resolve() + "/assets/_styles/core/icon-sprite.scss"
+                                'dest': '../../../public/styles',
+                                'sprite': '../images/svg/icon-sprite.svg',
+                                'bust': true,
+                                'prefix': '.',
+                                'dimensions': true,
+                                'layout': 'vertical',
+                                'render': {
+                                  'scss': {
+                                      'dest': path.resolve() + '/assets/_styles/core/icon-sprite.scss'
                                   }
                               },
                             }

--- a/assets/_js/init/selfserve.js
+++ b/assets/_js/init/selfserve.js
@@ -17,7 +17,6 @@ OLCS.ready(function() {
   OLCS.searchFilter();
 
   //load govuk frontend
-  window.GOVUKFrontend.initAll();
   module.exports = window.cookieManager;
   //window.cookieManager.init(window.cookieConfig);
   OLCS.GOVUKversion = "4.3.0";

--- a/assets/_js/init/selfserve.js
+++ b/assets/_js/init/selfserve.js
@@ -19,5 +19,5 @@ OLCS.ready(function() {
   //load govuk frontend
   module.exports = window.cookieManager;
   //window.cookieManager.init(window.cookieConfig);
-  OLCS.GOVUKversion = "4.3.0";
+  OLCS.GOVUKversion = "5.4.1";
 });

--- a/assets/_styles/core/legacy.scss
+++ b/assets/_styles/core/legacy.scss
@@ -43,8 +43,8 @@ $light-blue-50: #96c6e2;
 $light-blue-25: #d5e8f3;
 
 // New Transport Light
-$NTA-Light: $govuk-font-family-nta;
-$NTA-Light-Tabular: $govuk-font-family-nta-tabular;
+$NTA-Light: $govuk-font-family;
+$NTA-Light-Tabular: $govuk-font-family;
 
 @mixin media($size: false, $max-width: false, $min-width: false, $ignore-for-ie: false) {
     @if $size == desktop {

--- a/assets/_styles/themes/internal.scss
+++ b/assets/_styles/themes/internal.scss
@@ -6,8 +6,8 @@
 $app: internal;
 
 // Vendor
-@import '../../../node_modules/govuk-frontend/govuk/components/radios/radios';
-@import '../../../node_modules/govuk-frontend/govuk/all';
+@import '../../../node_modules/govuk-frontend/dist/govuk/components/radios/radios';
+@import '../../../node_modules/govuk-frontend/dist/govuk/all';
 
 //govuk frontend toolkit legacy compatibility (main toolkit removed)
 @import '../core/legacy';

--- a/assets/_styles/themes/print.scss
+++ b/assets/_styles/themes/print.scss
@@ -8,7 +8,7 @@
 
 $app: print;
 
-@import '../../../node_modules/govuk-frontend/govuk/all';
+@import '../../../node_modules/govuk-frontend/dist/govuk/all';
 
 //govuk frontend toolkit legacy compatibility (main toolkit removed)
 @import '../core/legacy';

--- a/assets/_styles/themes/selfserve.scss
+++ b/assets/_styles/themes/selfserve.scss
@@ -6,7 +6,7 @@
 $app: selfserve;
 
 // Vendor
-@import '../../../node_modules/govuk-frontend/govuk/all';
+@import '../../../node_modules/govuk-frontend/dist/govuk/all';
 
 //govuk frontend toolkit legacy compatibility (main toolkit removed)
 @import '../core/legacy';

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@dvsa/cookie-manager": "^1.0.*",
         "autoprefixer": "^10.4.19",
         "chosen-npm": "^1.4.2",
-        "govuk-frontend": "5.4.1",
+        "govuk-frontend": "^5.4.1",
         "grunt": "^1.0.3",
         "grunt-cli": "^1.3.0",
         "grunt-contrib-clean": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@dvsa/cookie-manager": "^1.0.*",
         "autoprefixer": "^10.4.19",
         "chosen-npm": "^1.4.2",
-        "govuk-frontend": "4.8.0",
+        "govuk-frontend": "5.4.1",
         "grunt": "^1.0.3",
         "grunt-cli": "^1.3.0",
         "grunt-contrib-clean": "^2.0.1",
@@ -8555,9 +8555,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
-      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.1.tgz",
+      "integrity": "sha512-Gmd8LV++TRh9OF6tA+9KQTpwvlsLcri7qRjViz9ji4YuwZvX+c9TD7tyE+dnJcqsQsJfhr9Fp38m3Hu3H7EIcQ==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@dvsa/cookie-manager": "^1.0.*",
     "autoprefixer": "^10.4.19",
     "chosen-npm": "^1.4.2",
-    "govuk-frontend": "4.8.0",
+    "govuk-frontend": "5.4.1",
     "grunt": "^1.0.3",
     "grunt-cli": "^1.3.0",
     "grunt-contrib-clean": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@dvsa/cookie-manager": "^1.0.*",
     "autoprefixer": "^10.4.19",
     "chosen-npm": "^1.4.2",
-    "govuk-frontend": "5.4.1",
+    "govuk-frontend": "^5.4.1",
     "grunt": "^1.0.3",
     "grunt-cli": "^1.3.0",
     "grunt-contrib-clean": "^2.0.1",


### PR DESCRIPTION
## Description

Upgrade govuk-frontend to 5.x - requires loading new JS separately.

Related issue: [VOL-4716](https://dvsa.atlassian.net/browse/VOL-4716)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
